### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The examples assume webpage Markdown files have top-level directory ~/docs.
 ### Python code
 
 ```python
-import mkdocs-linkcheck as lc
+import mkdocs_linkcheck as lc
 lc.check_links("~/docs")
 ```
 
@@ -59,7 +59,7 @@ mkdocs-linkcheck
 or
 
 ```sh
-python -m mkdocs-linkcheck
+python -m mkdocs_linkcheck
 ```
 
 #### Command link arguments


### PR DESCRIPTION
`mkdocs-linkcheck` is not a valid module name in Python. The `-` (a minus sign) should be `_` (underscore).

> **Note**: `pip install mkdocs-linkcheck` (minus) doesn't have to be changed.

- [x] I've tested on my PC.