### PR TITLE
Fix homepage URL

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ name = mkdocs_linkcheck
 version = 1.0.6
 author = Byrne Reese
 author_email = byrne@majordojo.com
-url = https://github.com/byrnereese/mkdocs-linkchecker
+url = https://github.com/byrnereese/linkchecker-mkdocs
 description = Check links for Mkdocs-based sites, as well as any markdown-based website
 keywords =
   markdown


### PR DESCRIPTION
This URL will be shown as the homepage on [PyPI](https://pypi.org/project/mkdocs-linkcheck/).

Resolves #1