### PR TITLE
Add requests package to dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ include_package_data = True
 packages = find:
 install_requires =
   aiohttp >= 3.3
+  requests >= 2.4
 package_dir=
     =src
 
@@ -45,8 +46,6 @@ lint =
   flake8-builtins
   flake8-blind-except
   mypy
-requests =
-  requests
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
Closes #2 and #7.

requests >= 2.4 is required since earlier versions result in the following error:

```
AttributeError: module 'requests.exceptions' has no attribute 'ReadTimeout'
```