### PR TITLE
Fix help description for local argument

### DIFF
--- a/src/mkdocs_linkcheck/__main__.py
+++ b/src/mkdocs_linkcheck/__main__.py
@@ -42,7 +42,7 @@ def main():
         action="append")
     p.add_argument(
         "-l","--local",
-        help="only check local files",
+        help="only check local links",
         action="store_true")
     p.add_argument(
         "-r", "--recurse",


### PR DESCRIPTION
From what I've seen, this argument toggles whether only local links should be checked or not.
Since this tool can only be run on local files, the help description for the argument seems to be wrong.